### PR TITLE
Router execute callback

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,12 @@
 {
   "rules": {
-    "consistent-return": 2,
+    "consistent-return": 0,
     "curly": 2,
     "dot-notation": 2,
     "eqeqeq": 2,
     "guard-for-in": 2,
     "indent": [2, 2, {"SwitchCase": 1}],
+    "keyword-spacing": 2,
     "linebreak-style": [2, "unix"],
     "new-cap": 1,
     "no-caller": 2,
@@ -44,7 +45,6 @@
     "no-with": 2,
     "quotes": [2, "single"],
     "semi": [2, "always"],
-    "space-after-keywords": 2,
     "space-before-blocks": 2,
     "space-in-parens": [2, "never"],
     "vars-on-top": 2,

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,11 +95,9 @@ module.exports = function SocketioProtocol () {
           var requestObject = new this.context.RequestObject(data, {}, this.protocol);
 
           this.context.getRouter().execute(requestObject, connection, (error, responseObject) => {
-            if (error) {
-              return this.io.to(socket.id).emit(requestObject.requestId, error.toJson());
-            }
+            var payload = error ? error.toJson() : responseObject.toJson();
 
-            this.io.to(socket.id).emit(requestObject.requestId, responseObject.toJson());
+            this.io.to(socket.id).emit(requestObject.requestId, payload);
           });
         });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,13 +94,13 @@ module.exports = function SocketioProtocol () {
         socket.on(this.config.room, data => {
           var requestObject = new this.context.RequestObject(data, {}, this.protocol);
 
-          this.context.getRouter().execute(requestObject, connection)
-            .then(responseObject => {
-              this.io.to(socket.id).emit(requestObject.requestId, responseObject.toJson());
-            })
-            .catch(error => {
-              this.io.to(socket.id).emit(requestObject.requestId, error.toJson());
-            });
+          this.context.getRouter().execute(requestObject, connection, (error, responseObject) => {
+            if (err) {
+              return this.io.to(socket.id).emit(requestObject.requestId, error.toJson());
+            }
+
+            this.io.to(socket.id).emit(requestObject.requestId, responseObject.toJson());
+          });
         });
 
         socket.on('disconnect', () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ module.exports = function SocketioProtocol () {
           var requestObject = new this.context.RequestObject(data, {}, this.protocol);
 
           this.context.getRouter().execute(requestObject, connection, (error, responseObject) => {
-            if (err) {
+            if (error) {
               return this.io.to(socket.id).emit(requestObject.requestId, error.toJson());
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-socketio",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Protocol plugin adding Socket.io support to Kuzzle",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -32,18 +32,18 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "socket.io": "^1.4.4"
+    "socket.io": "^1.4.5"
   },
   "devDependencies": {
     "codecov": "^1.0.1",
-    "eslint": "^1.10.3",
+    "eslint": "^2.5.3",
     "grunt": "^0.4.5",
-    "grunt-contrib-jshint": "^0.11.3",
-    "gruntify-eslint": "^1.3.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "gruntify-eslint": "^2.0.0",
     "istanbul": "^0.4.2",
-    "mocha": "^2.3.4",
-    "proxyquire": "^1.7.3",
-    "should": "^8.1.0"
+    "mocha": "^2.4.5",
+    "proxyquire": "^1.7.4",
+    "should": "^8.3.0"
   },
   "maintainers": [
     {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,9 +37,9 @@ describe('plugin implementation', function () {
 
         emitter.sockets = { connected: {} };
         emitter.sockets.connected[fakeId] = {
-          join: channel => linkedChannel = channel,
-          leave: channel => linkedChannel = channel,
-          emit: (event, payload) => notification = {event, payload}
+          join: channel => { linkedChannel = channel; },
+          leave: channel => { linkedChannel = channel; },
+          emit: (event, payload) => { notification = {event, payload}; }
         };
 
         return emitter;
@@ -258,15 +258,15 @@ describe('plugin implementation', function () {
               connected = true;
               return Promise.resolve(connection);
             },
-            execute: (request, conn) => {
+            execute: (request, conn, cb) => {
               should(conn).be.eql(connection);
               executed = true;
 
               if (request.errorMe) {
-                return Promise.reject(response);
+                return cb(response);
               }
 
-              return Promise.resolve(response);
+              cb(null, response);
             },
             removeConnection: () => {
               disconnected = true;


### PR DESCRIPTION
Future versions of Kuzzle use a callback instead of a promise to notify the plugin of the end of a request execution.