### PR TITLE
Follow https://github.com/kuzzleio/kuzzle/pull/255

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,9 +95,7 @@ module.exports = function SocketioProtocol () {
           var requestObject = new this.context.RequestObject(data, {}, this.protocol);
 
           this.context.getRouter().execute(requestObject, connection, (error, responseObject) => {
-            var payload = error ? error.toJson() : responseObject.toJson();
-
-            this.io.to(socket.id).emit(requestObject.requestId, payload);
+            this.io.to(socket.id).emit(requestObject.requestId, responseObject.toJson());
           });
         });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-socketio",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Protocol plugin adding Socket.io support to Kuzzle",
   "main": "./lib/index.js",
   "repository": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -263,7 +263,7 @@ describe('plugin implementation', function () {
               executed = true;
 
               if (request.errorMe) {
-                return cb(response);
+                return cb('errorMe', response);
               }
 
               cb(null, response);


### PR DESCRIPTION
the "error" parameter in the callback is no longer a ResponseObject, we always emit the "responseObject"