### PR TITLE
KUZ 552 Response from router.execute() is not an ResponseObject

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,8 +94,8 @@ module.exports = function SocketioProtocol () {
         socket.on(this.config.room, data => {
           var requestObject = new this.context.RequestObject(data, {}, this.protocol);
 
-          this.context.getRouter().execute(requestObject, connection, (error, responseObject) => {
-            this.io.to(socket.id).emit(requestObject.requestId, responseObject.toJson());
+          this.context.getRouter().execute(requestObject, connection, (error, response) => {
+            this.io.to(socket.id).emit(requestObject.requestId, response);
           });
         });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,21 +90,21 @@ module.exports = function SocketioProtocol () {
     }
 
     this.context.getRouter().newConnection(this.protocol, socket.id)
-      .then(connection => {
+      .then(context => {
         socket.on(this.config.room, data => {
           var requestObject = new this.context.RequestObject(data, {}, this.protocol);
 
-          this.context.getRouter().execute(requestObject, connection, (error, response) => {
+          this.context.getRouter().execute(requestObject, context, (error, response) => {
             this.io.to(socket.id).emit(requestObject.requestId, response);
           });
         });
 
         socket.on('disconnect', () => {
-          this.context.getRouter().removeConnection(connection);
+          this.context.getRouter().removeConnection(context);
         });
 
         socket.on('error', () => {
-          this.context.getRouter().removeConnection(connection);
+          this.context.getRouter().removeConnection(context);
         });
       })
       .catch(err => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -304,7 +304,7 @@ describe('plugin implementation', function () {
           should(connected).be.true();
           should(executed).be.true();
           should(disconnected).be.false();
-          should(messageSent).be.eql(serializedResponse);
+          should(messageSent).be.eql(response);
           should(destination).be.eql(fakeRequestId);
           done();
         }, 40);
@@ -323,7 +323,7 @@ describe('plugin implementation', function () {
           should(connected).be.true();
           should(executed).be.true();
           should(disconnected).be.false();
-          should(messageSent).be.eql(serializedResponse);
+          should(messageSent).be.eql(response);
           should(destination).be.eql(fakeRequestId);
           done();
         }, 20);


### PR DESCRIPTION
Because plugins protocol are now loaded by LB, and the LB has only a `response` and not a `responseObject`, we can return directly `response` and not `responseObject.toJson()`